### PR TITLE
fix: correct typo

### DIFF
--- a/spec/lib/pubsubhub_spec.rb
+++ b/spec/lib/pubsubhub_spec.rb
@@ -9,7 +9,7 @@ describe PubSubHub do
     PubSubHub.register(some_event: registration)
   end
 
-  after { PubSubHub.register(@registry) if @registery }
+  after { PubSubHub.register(@registry) if @registry }
 
   context 'with missing a listener' do
     it 'raises an error' do


### PR DESCRIPTION
Added nearly 8 years ago in 8f1d9b07c12c6b67706fb3bc2628a65f6b730e63.